### PR TITLE
Changed all ENTRYPOINTs in all Dockerfiles to use the exec form.

### DIFF
--- a/wso2am/Dockerfile
+++ b/wso2am/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 10397 8280 8243 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2as/Dockerfile
+++ b/wso2as/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2bps/Dockerfile
+++ b/wso2bps/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2brs/Dockerfile
+++ b/wso2brs/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2cep/Dockerfile
+++ b/wso2cep/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 7611 7711 9763 9443 9611 9711
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2das/Dockerfile
+++ b/wso2das/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 7611 7711 9763 9443 9611 9711
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2dss/Dockerfile
+++ b/wso2dss/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2es/Dockerfile
+++ b/wso2es/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2esb/Dockerfile
+++ b/wso2esb/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 8280 8243 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2greg/Dockerfile
+++ b/wso2greg/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2is/Dockerfile
+++ b/wso2is/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 8000 9763 9443 10500
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/wso2mb/Dockerfile
+++ b/wso2mb/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /mnt
 # Expose transport ports
 EXPOSE 1883 8833 5672 8672 7611 9763 9443
 
-ENTRYPOINT /usr/local/bin/init.sh
+ENTRYPOINT ["/usr/local/bin/init.sh"]


### PR DESCRIPTION
According to the Dockerfile reference (https://docs.docker.com/engine/reference/builder/#entrypoint) the preferred way to use the ENTRYPOINT instruction is the exec form. 

This PR does exactly that, changing all Dockerfiles to the preferred form.
