### PR TITLE
encounter EOF error when extraing jdk in Mac OSX

### DIFF
--- a/common/provision/default/image-config.sh
+++ b/common/provision/default/image-config.sh
@@ -38,7 +38,8 @@ echo "unpacking ${WSO2_SERVER}-${WSO2_SERVER_VERSION}.zip to /mnt"
 unzip -q /mnt/${WSO2_SERVER}-${WSO2_SERVER_VERSION}.zip -d /mnt
 mkdir -p ${jdk_install_dir}
 echo "unpacking the JDK to ${jdk_install_dir}"
-tar -xf /mnt/jdk*tar.gz -C ${jdk_install_dir} --strip-components=1
+# tar -xf /mnt/jdk*tar.gz -C ${jdk_install_dir} --strip-components=1
+gunzip < /mnt/jdk*tar.gz | tar -xf - -C ${jdk_install_dir} --strip-components=1
 ln -s ${jdk_install_dir} ${java_home_dir}
 echo "created symlink for java: ${java_home_dir} -> ${jdk_install_dir}"
 


### PR DESCRIPTION
Replace "tar -xf /mnt/jdk_tar.gz -C ${jdk_install_dir} --strip-components=1" with "gunzip < /mnt/jdk_tar.gz | tar -xf - -C ${jdk_install_dir} --strip-components=1"
